### PR TITLE
New netcode

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "immutable": "https://github.com/thomasboyt/immutable-js.git#fix-record-update-return-types",
     "lodash.clamp": "^4.0.1",
     "lodash.sample": "^4.1.1",
-    "p2": "https://github.com/thomasboyt/p2.js#fix-material-options",
+    "p2": "https://github.com/thomasboyt/p2.js#master-built",
     "raf": "^3.2.0",
     "randomcolor": "^0.4.3",
     "raven": "^0.10.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "build-client": "rm -rf build/client && webpack --config webpack/production.js",
     "deploy": " npm run deploy-client && git push heroku master",
     "deploy-client": "fly production",
-    "deploy-staging": "fly client-staging",
+    "deploy-beta": "fly client-staging",
+    "deploy-staging-client": "MANYGOLF_SERVER_URL=wss://manygolf-staging.herokuapp.com/ npm run build-client && surge -d manygolf.surge.sh -p ./build/client",
     "postinstall": "webpack --config webpack/server.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "raf": "^3.2.0",
     "randomcolor": "^0.4.3",
     "raven": "^0.10.0",
-    "raven-js": "^2.3.0",
+    "raven-js": "^3.8.0",
     "react": "^15.1.0",
     "react-dom": "^15.1.0",
     "react-redux": "^4.4.5",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "deploy": " npm run deploy-client && git push heroku master",
     "deploy-client": "fly production",
     "deploy-beta": "fly client-staging",
-    "deploy-staging-client": "MANYGOLF_SERVER_URL=wss://manygolf-staging.herokuapp.com/ npm run build-client && surge -d manygolf.surge.sh -p ./build/client",
+    "deploy-staging-client": "MANYGOLF_SERVER_URL=wss://manygolf-staging.herokuapp.com/ npm run build-client && surge -d manygolf-staging.surge.sh -p ./build/client",
     "postinstall": "webpack --config webpack/server.js"
   },
   "devDependencies": {

--- a/src/client/flags.ts
+++ b/src/client/flags.ts
@@ -2,3 +2,4 @@ import {getFlag, flagTypes} from './util/featureFlags';
 
 export const useNewNetcode: boolean = getFlag('newNetcode', flagTypes.bool, false);
 export const debugRender: boolean = getFlag('debugRender', flagTypes.bool, false);
+export const enableDebugLog: boolean = getFlag('log', flagTypes.bool, false);

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -60,9 +60,11 @@ export default function initialize(): Store<State> {
       if (document.hidden) {
         ws.send(messageReqPauseStream());
         pausedWs = true;
+        runLoop.stop();
       } else {
         ws.send(messageReqResumeStream());
         pausedWs = false;
+        runLoop.start();
       }
     }
   });

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -56,12 +56,14 @@ export default function initialize(): Store<State> {
 
   let pausedWs = false;
   document.addEventListener('visibilitychange', () => {
-    if (document.hidden) {
-      ws.send(messageReqPauseStream());
-      pausedWs = true;
-    } else {
-      ws.send(messageReqResumeStream());
-      pausedWs = false;
+    if (ws.connected) {
+      if (document.hidden) {
+        ws.send(messageReqPauseStream());
+        pausedWs = true;
+      } else {
+        ws.send(messageReqResumeStream());
+        pausedWs = false;
+      }
     }
   });
 

--- a/src/client/initialize.ts
+++ b/src/client/initialize.ts
@@ -11,6 +11,8 @@ import {
 
 import { registerListeners } from './util/inputter';
 
+import {messageReqPauseStream, messageReqResumeStream} from '../universal/protocol';
+
 import testMsgs from '../testData';
 
 /*
@@ -51,6 +53,17 @@ export default function initialize(): Store<State> {
   });
 
   runLoop.start();
+
+  let pausedWs = false;
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      ws.send(messageReqPauseStream());
+      pausedWs = true;
+    } else {
+      ws.send(messageReqResumeStream());
+      pausedWs = false;
+    }
+  });
 
   return store;
 }

--- a/src/client/records.ts
+++ b/src/client/records.ts
@@ -101,7 +101,7 @@ export class MatchEndPlayer extends MatchEndPlayerRec {
 
 const RoundRec = I.Record({
   level: null,
-  world: null,
+  worlds: null,
   ball: new Ball(),
   holeSensor: null,
 
@@ -122,7 +122,7 @@ const RoundRec = I.Record({
 
 export class Round extends RoundRec {
   level: Level;
-  world: p2.World;
+  worlds: I.Map<number, p2.World>;
   ball: Ball;
   holeSensor: p2.Body;
 

--- a/src/client/records.ts
+++ b/src/client/records.ts
@@ -17,20 +17,24 @@ export enum SwingMeterDirection {
   descending
 }
 
+const PlayerPhysicsRec = I.Record({
+  ball: null,
+  holeSensor: null,
+  world: null,
 
-const BallRec = I.Record({
-  body: null,
-  lastX: null,
+  lastBallX: null,
 });
 
-export class Ball extends BallRec {
-  body: p2.Body;
-  lastX: number;
+export class PlayerPhysics extends PlayerPhysicsRec {
+  ball: p2.Body;
+  holeSensor: p2.Body;
+  world: p2.World;
+
+  lastBallX: number;
 }
 
 
 const PlayerRec = I.Record({
-  body: null,
   color: null,
   name: null,
   id: null,
@@ -38,7 +42,6 @@ const PlayerRec = I.Record({
 });
 
 export class Player extends PlayerRec {
-  body: p2.Body;
   color: string;
   name: string;
   id: number;
@@ -101,9 +104,7 @@ export class MatchEndPlayer extends MatchEndPlayerRec {
 
 const RoundRec = I.Record({
   level: null,
-  worlds: null,
-  ball: new Ball(),
-  holeSensor: null,
+  playerPhysics: null,
 
   aimDirection: -45,  // angle (in degrees) relative to pointing ->
   swingPower: 0,
@@ -122,8 +123,7 @@ const RoundRec = I.Record({
 
 export class Round extends RoundRec {
   level: Level;
-  worlds: I.Map<number, p2.World>;
-  ball: Ball;
+  playerPhysics: I.Map<number, PlayerPhysics>;
   holeSensor: p2.Body;
 
   aimDirection: number;

--- a/src/client/reducer.ts
+++ b/src/client/reducer.ts
@@ -431,8 +431,6 @@ export default createImmutableReducer<State>(new State(), {
   [`ws:${TYPE_PLAYER_CONNECTED}`]: (state: State, action) => {
     const data = <MessagePlayerConnected>action.data;
 
-    // const ball = createBall(state.round.level.spawn);
-    // state.round.world.addBody(ball);
     const playerPhysics = createPlayerPhysics(state.round.level);
 
     return state

--- a/src/client/reducer.ts
+++ b/src/client/reducer.ts
@@ -80,6 +80,8 @@ const maxSubSteps = (TIMER_MS / 1000) * (1 / fixedStep);
 const moveSpeed = 50;  // degrees per second
 
 function syncWorld(state: State, data: MessageSync): State {
+  console.log('sync ----');
+
   // Update player states if they are over some threshold at time
   data.players.forEach((playerPosition) => {
     const player = state.players.get(playerPosition.id);
@@ -194,7 +196,8 @@ function newLevel(state: State, data: MessageInitial) {
 }
 
 function applySwing(state: State, data: MessagePlayerSwing) {
-  console.log(`playing swing ${data.id} ${data.time}`);
+  const dt = (state.time - data.time) / 1000;
+  console.log(`playing swing ${dt} ${data.id} ${data.time}`);
 
   const player = state.players.get(data.id);
 

--- a/src/client/reducer.ts
+++ b/src/client/reducer.ts
@@ -65,6 +65,8 @@ import {
   Match,
 } from './records';
 
+const runBehind = 50;  // ms to enforce run-behind
+
 const SYNC_THRESHOLD = 2;
 
 const fixedStep = 1 / 60;
@@ -422,7 +424,7 @@ export default createImmutableReducer<State>(new State(), {
       }, I.Map()))
       .update((s) => newLevel(s, data))
       .set('gameState', data.gameState)
-      .set('time', data.time)
+      .set('time', data.time - runBehind)
       .set('match', new Match({
         leaderId: data.leaderId,
         matchEndsAt: Date.now() + data.matchEndsIn,
@@ -497,7 +499,8 @@ export default createImmutableReducer<State>(new State(), {
   [`ws:${TYPE_SYNC}`]: (state: State, {data}: {data: MessageSync}) => {
     const time = data.time;
 
-    // if client is ahead of server, somehow...
+    // if client is ahead of server, due to lag during the time it took to receive message...
+    // this should be an exceptional case, ideally
     if (time < state.time) {
       return syncWorld(state, data);
 

--- a/src/client/reducer.ts
+++ b/src/client/reducer.ts
@@ -210,8 +210,7 @@ function applySwing(state: State, data: MessagePlayerSwing) {
   body.velocity[0] = data.velocity[0];
   body.velocity[1] = data.velocity[1];
 
-  const dt = (state.time - data.time) / 1000;
-  state.round.playerPhysics.get(data.id).world.step(fixedStep, -(dt * 3), maxSubSteps);
+  state.round.playerPhysics.get(data.id).world.step(fixedStep, dt * 3, maxSubSteps);
 
   return state;
 }
@@ -257,7 +256,6 @@ export default createImmutableReducer<State>(new State(), {
     state.round.playerPhysics.forEach((phys) => {
       phys.world.step(fixedStep, dt * 3, maxSubSteps);
     });
-
 
     // update saved positions
     state = state.set('players', state.players.map((player) => {

--- a/src/client/reducer.ts
+++ b/src/client/reducer.ts
@@ -406,10 +406,10 @@ export default createImmutableReducer<State>(new State(), {
     return newState;
   },
 
-  [`ws:${TYPE_INITIAL}`]: (state: State, action) => {
+  [`ws:${TYPE_INITIAL}`]: (prevState: State, action) => {
     const data = <MessageInitial>action.data;
 
-    let newState = state
+    let newState = prevState
       .set('connectionState', ConnectionState.connected)
       .set('name', data.self.name)
       .set('id', data.self.id)
@@ -430,13 +430,17 @@ export default createImmutableReducer<State>(new State(), {
         matchEndsAt: Date.now() + data.matchEndsIn,
       }));
 
-    // resume scored state
+    // resume current-player-specific state
+    // (this could theoretically be moved to newLevel logic, I think?)
     if (!data.isObserver) {
+      newState = newState.setIn(['round', 'strokes'], data.self.strokes);
+
+      // restore scored state
       if (data.self.scored) {
         newState = enterScored(newState);
         // if goal text was previously set, use it
-        if (state.round.goalText) {
-          newState = newState.setIn(['round', 'goalText'], state.round.goalText)
+        if (prevState.round.goalText) {
+          newState = newState.setIn(['round', 'goalText'], prevState.round.goalText)
         }
       }
     }

--- a/src/client/reducer.ts
+++ b/src/client/reducer.ts
@@ -471,7 +471,7 @@ export default createImmutableReducer<State>(new State(), {
         newState = enterScored(newState);
         // if goal text was previously set, use it
         if (prevState.round.goalText) {
-          newState = newState.setIn(['round', 'goalText'], prevState.round.goalText)
+          newState = newState.setIn(['round', 'goalText'], prevState.round.goalText);
         }
       }
     }

--- a/src/client/reducer.ts
+++ b/src/client/reducer.ts
@@ -409,7 +409,7 @@ export default createImmutableReducer<State>(new State(), {
   [`ws:${TYPE_INITIAL}`]: (state: State, action) => {
     const data = <MessageInitial>action.data;
 
-    return state
+    let newState = state
       .set('connectionState', ConnectionState.connected)
       .set('name', data.self.name)
       .set('id', data.self.id)
@@ -429,6 +429,19 @@ export default createImmutableReducer<State>(new State(), {
         leaderId: data.leaderId,
         matchEndsAt: Date.now() + data.matchEndsIn,
       }));
+
+    // resume scored state
+    if (!data.isObserver) {
+      if (data.self.scored) {
+        newState = enterScored(newState);
+        // if goal text was previously set, use it
+        if (state.round.goalText) {
+          newState = newState.setIn(['round', 'goalText'], state.round.goalText)
+        }
+      }
+    }
+
+    return newState;
   },
 
   [`ws:${TYPE_PLAYER_CONNECTED}`]: (state: State, action) => {

--- a/src/client/reducer.ts
+++ b/src/client/reducer.ts
@@ -247,6 +247,18 @@ function levelOver(state: State, data: MessageLevelOver) {
     .setIn(['round', 'roundRankedPlayers'], rankedPlayers);
 }
 
+function matchOver(state: State, data: MessageMatchOver) {
+  const rankedPlayers: I.List<MatchEndPlayer> = I.fromJS(data.matchRankedPlayers)
+    .map((player) => new MatchEndPlayer(player));
+
+  const nextMatchTime = Date.now() + data.nextMatchIn;
+
+  return state
+    .set('gameState', GameState.matchOver)
+    .setIn(['match', 'matchRankedPlayers'], rankedPlayers)
+    .setIn(['match', 'nextMatchTime'],  nextMatchTime);
+}
+
 function getCurrentPlayerPhysics(state: State): PlayerPhysics {
   return state.round.playerPhysics.get(state.id);
 }
@@ -445,6 +457,8 @@ export default createImmutableReducer<State>(new State(), {
 
     if (data.gameState === GameState.levelOver) {
       newState = levelOver(newState, data.levelOverState);
+    } else if (data.gameState === GameState.matchOver) {
+      newState = matchOver(newState, data.matchOverState);
     }
 
     // resume current-player-specific state
@@ -541,15 +555,7 @@ export default createImmutableReducer<State>(new State(), {
   },
 
   [`ws:${TYPE_MATCH_OVER}`]: (state: State, {data}: {data: MessageMatchOver}) => {
-    const rankedPlayers: I.List<MatchEndPlayer> = I.fromJS(data.matchRankedPlayers)
-      .map((player) => new MatchEndPlayer(player));
-
-    const nextMatchTime = Date.now() + data.nextMatchIn;
-
-    return state
-      .set('gameState', GameState.matchOver)
-      .setIn(['match', 'matchRankedPlayers'], rankedPlayers)
-      .setIn(['match', 'nextMatchTime'],  nextMatchTime);
+    return matchOver(state, data);
   },
 
   'disconnect': (state: State) => {

--- a/src/client/render/index.ts
+++ b/src/client/render/index.ts
@@ -260,14 +260,6 @@ function renderBalls(ctx: CanvasRenderingContext2D, state: State) {
   ctx.fill();
   ctx.closePath();
 
-  ctx.beginPath();
-  ctx.arc(ballPos[0], ballPos[1], 2.5, 0, 2 * Math.PI);
-  ctx.fillStyle = ballColor;
-  ctx.strokeStyle = ballColor; // add stroke so it's the same size as the ghosts
-  ctx.fill();
-  ctx.stroke();
-  ctx.closePath();
-
   renderBall(ctx, ballPos[0], ballPos[1], ballColor, ballColor);
 
   if (state.match.leaderId === state.id) {

--- a/src/client/render/index.ts
+++ b/src/client/render/index.ts
@@ -260,7 +260,7 @@ function renderBalls(ctx: CanvasRenderingContext2D, state: State) {
   ctx.fill();
   ctx.closePath();
 
-  renderBall(ctx, ballPos[0], ballPos[1], ballColor, ballColor);
+  renderBall(ctx, ballPos[0], ballPos[1], state.color, textColor);
 
   if (state.match.leaderId === state.id) {
     drawCrown(ctx, ballPos[0], ballPos[1]);

--- a/src/client/render/index.ts
+++ b/src/client/render/index.ts
@@ -213,7 +213,7 @@ function renderBalls(ctx: CanvasRenderingContext2D, state: State) {
       return;
     }
 
-    const pos = player.body.interpolatedPosition;
+    const pos = state.round.playerPhysics.get(player.id).ball.interpolatedPosition;
     renderBall(ctx, pos[0], pos[1], player.color, textColor);
 
     if (state.match.leaderId === player.id) {
@@ -225,27 +225,20 @@ function renderBalls(ctx: CanvasRenderingContext2D, state: State) {
   // Draw chat bubbles
   //
   state.chats.forEach((chat, id) => {
-    let x, y, onLeft = false;
 
     if (!state.players.get(id)) {
       // Chat received but no player/ball is present, so don't render!
       return;
     }
 
-    if (id === state.id) {
-      // render over current player
-      x = state.round.ball.body.interpolatedPosition[0];
-      y = state.round.ball.body.interpolatedPosition[1];
+    const pos = state.round.playerPhysics.get(id).ball.interpolatedPosition;
+    const x = pos[0];
+    const y = pos[1];
 
-      if (state.round.aimDirection > -90) {
-        onLeft = true;
-      }
-
-    } else {
-      // render over other player
-      const pos = state.players.get(id).body.interpolatedPosition;
-      x = pos[0];
-      y = pos[1];
+    // if it's over the current player, don't overlap the aim arrow
+    let onLeft = false;
+    if (id === state.id && state.round.aimDirection > -90) {
+      onLeft = true;
     }
 
     renderChat(ctx, {ballX: x, ballY: y, emoticon: chat.emoticon, onLeft});
@@ -258,7 +251,7 @@ function renderBalls(ctx: CanvasRenderingContext2D, state: State) {
   //
   // Draw player ball
   //
-  const ballPos = state.round.ball.body.interpolatedPosition;
+  const ballPos = state.round.playerPhysics.get(state.id).ball.interpolatedPosition;
 
   // draw a translucent "shadow" around the player ball to make it easy to keep tack
   ctx.beginPath();

--- a/src/client/render/leaderboard.ts
+++ b/src/client/render/leaderboard.ts
@@ -88,10 +88,13 @@ export default function renderLeaderBoard(ctx: CanvasRenderingContext2D, state: 
   if (!state.isObserver) {
     ctx.font = 'normal 16px "Press Start 2P"';
 
-    if (state.round.scored) {
-      const players = state.round.roundRankedPlayers;
-      const position = players.findIndex((player) => player.id === state.id) + 1;
-      ctx.fillText(`You placed ${toOrdinal(position)}`, WIDTH / 2, y);
+    // can't use state.round.scored here because the round-end message can be sent before this is
+    // computed locally due to lag
+    const players = state.round.roundRankedPlayers;
+    const idx = players.findIndex((player) => player.id === state.id);
+
+    if (players.get(idx).scored) {
+      ctx.fillText(`You placed ${toOrdinal(idx + 1)}`, WIDTH / 2, y);
 
     } else {
       ctx.fillText('You didn\'t make it in :(', WIDTH / 2, y);

--- a/src/client/render/matchEnd.ts
+++ b/src/client/render/matchEnd.ts
@@ -168,6 +168,6 @@ export default function renderMatchEnd(ctx: CanvasRenderingContext2D, state: Sta
   if (place > -1) {
     ctx.fillText(`You finished ${toOrdinal(place + 1)} of ${players.size}!`, WIDTH / 2, HEIGHT - 5);
   } else {
-    ctx.fillText('Next match starts soon...', WIDTH / 2, HEIGHT - 5)
+    ctx.fillText('Next match starts soon...', WIDTH / 2, HEIGHT - 5);
   }
 }

--- a/src/client/render/matchEnd.ts
+++ b/src/client/render/matchEnd.ts
@@ -159,11 +159,15 @@ export default function renderMatchEnd(ctx: CanvasRenderingContext2D, state: Sta
   drawPodium(ctx, players.get(1), 2, 100);
   drawPodium(ctx, players.get(2), 3, 500);
 
+  ctx.fillStyle = 'white';
+  ctx.font = 'normal 16px "Press Start 2P"';
+  ctx.textAlign = 'center';
+
   const place = players.findIndex((player) => player.id === state.id);
+
   if (place > -1) {
-    ctx.fillStyle = 'white';
-    ctx.font = 'normal 16px "Press Start 2P"';
-    ctx.textAlign = 'center';
     ctx.fillText(`You finished ${toOrdinal(place + 1)} of ${players.size}!`, WIDTH / 2, HEIGHT - 5);
+  } else {
+    ctx.fillText('Next match starts soon...', WIDTH / 2, HEIGHT - 5)
   }
 }

--- a/src/client/ws.ts
+++ b/src/client/ws.ts
@@ -88,6 +88,10 @@ class WSConnection {
       this._ws.send(strMsg);
     }
   }
+
+  get connected(): boolean {
+    return this._ws.readyState === this._ws.OPEN;
+  }
 }
 
 const ws = new WSConnection();

--- a/src/server/ManygolfSocketManager.ts
+++ b/src/server/ManygolfSocketManager.ts
@@ -27,6 +27,8 @@ import {
   Player,
 } from './records';
 
+import {createInitial} from './messages';
+
 /*
  * Connection manager
  */
@@ -184,58 +186,6 @@ export default class ManygolfSocketManager extends SocketManager {
   sendInitial(id: number) {
     const state = this.store.getState();
 
-    const players = state.players.map((player, id) => {
-      return {
-        id,
-        color: player.color,
-        name: player.name,
-        position: [
-          player.body.position[0],
-          player.body.position[1],
-        ],
-        velocity: [
-          player.body.velocity[0],
-          player.body.velocity[1],
-        ],
-        scored: player.scored,
-        strokes: player.strokes,
-      };
-    });
-
-
-    let self;
-    let isObserver: boolean;
-    if (players.has(id)) {
-      self = players.get(id);
-      isObserver = false;
-
-    } else {
-      const observer = state.observers.get(id);
-      self = {
-        id: observer.id,
-        name: observer.name,
-        color: observer.color,
-      };
-      isObserver = true;
-    }
-
-    this.sendTo(id, messageInitial({
-      gameState: state.gameState,
-
-      self,
-
-      isObserver,
-
-      leaderId: state.leaderId,
-
-      players: players.toArray(),
-
-      level: state.levelData,
-      expiresIn: state.expTime - Date.now(),
-
-      time: state.time,
-      matchEndsIn: state.matchEndTime - Date.now(),
-    }));
-
+    this.sendTo(id, createInitial(state, id));
   }
 }

--- a/src/server/ManygolfSocketManager.ts
+++ b/src/server/ManygolfSocketManager.ts
@@ -8,7 +8,6 @@ import WebSocket from 'uws';
 import p2 from 'p2';
 
 import {
-  messageInitial,
   messagePlayerConnected,
   messagePlayerDisconnected,
   messageDisplayMessage,

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -10,7 +10,6 @@ import {
   messageIdleKicked,
   messageLevel,
   messageSync,
-  messageLevelOver,
   messageHurryUp,
   messageMatchOver,
 } from '../universal/protocol';
@@ -32,6 +31,8 @@ import {
   Level,
   State,
 } from './records';
+
+import {createLevelOver} from './messages';
 
 type Dispatch = (action: any) => State;
 
@@ -188,36 +189,12 @@ export function sendSyncMessage(
   }));
 }
 
-export function levelOver(dispatch: Dispatch, socks: ManygolfSocketManager,
-  {players}: {players: PlayersMap}
-) {
+export function levelOver(dispatch: Dispatch, socks: ManygolfSocketManager) {
   const newState = dispatch({
     type: 'levelOver',
   });
 
-  const rankedPlayers = newState.roundRankedPlayers;
-
-  socks.sendAll(messageLevelOver({
-    roundRankedPlayers: rankedPlayers.toArray().map((player) => {
-      // XXX: this references the players map from *before* they are updated with new points
-      const prevPoints = players.get(player.id).points;
-
-      return {
-        id: player.id,
-        color: player.color,
-        name: player.name,
-        strokes: player.strokes,
-        scoreTime: player.scoreTime,
-        scored: player.scored,
-
-        prevPoints,
-        addedPoints: player.points - prevPoints,
-      };
-    }),
-
-    expTime: newState.expTime,
-    leaderId: newState.leaderId,
-  }));
+  socks.sendAll(createLevelOver(newState));
 }
 
 export function checkHurryUp(

--- a/src/server/actions.ts
+++ b/src/server/actions.ts
@@ -11,7 +11,6 @@ import {
   messageLevel,
   messageSync,
   messageHurryUp,
-  messageMatchOver,
 } from '../universal/protocol';
 
 import {
@@ -32,7 +31,7 @@ import {
   State,
 } from './records';
 
-import {createLevelOver} from './messages';
+import {createLevelOver, createMatchOver} from './messages';
 
 type Dispatch = (action: any) => State;
 
@@ -128,19 +127,7 @@ export function endMatch(dispatch: Dispatch, socks: ManygolfSocketManager) {
     nextMatchAt,
   });
 
-  const rankedPlayers = state.matchRankedPlayers;
-
-  socks.sendAll(messageMatchOver({
-    nextMatchIn: MATCH_OVER_MS,
-    matchRankedPlayers: rankedPlayers.toArray().map((player) => {
-      return {
-        id: player.id,
-        color: player.color,
-        name: player.name,
-        points: player.points,
-      };
-    }),
-  }));
+  socks.sendAll(createMatchOver(state));
 }
 
 export function cycleLevel(dispatch: Dispatch, socks: ManygolfSocketManager) {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -122,13 +122,13 @@ runLoop.onTick((dt: number) => {
     if (players.size > 0 &&
         players.filter((player) => player.scored).size === players.size) {
       console.log('All players have finished');
-      levelOver(dispatch, socks, {players});
+      levelOver(dispatch, socks);
       return;
     }
 
     if (getState().expTime !== null && getState().expTime < Date.now()) {
       console.log('Timer expired');
-      levelOver(dispatch, socks, {players});
+      levelOver(dispatch, socks);
       return;
     }
 

--- a/src/server/messages.ts
+++ b/src/server/messages.ts
@@ -1,0 +1,84 @@
+import {messageLevelOver, messageInitial} from '../universal/protocol';
+import {State} from './records';
+import {GameState} from '../universal/constants';
+
+export function createInitial(state: State, playerId: number) {
+  const players = state.players.map((player, id) => {
+    return {
+      id,
+      color: player.color,
+      name: player.name,
+      position: [
+        player.body.position[0],
+        player.body.position[1],
+      ],
+      velocity: [
+        player.body.velocity[0],
+        player.body.velocity[1],
+      ],
+      scored: player.scored,
+      strokes: player.strokes,
+    };
+  });
+
+  let self;
+  let isObserver: boolean;
+  if (players.has(playerId)) {
+    self = players.get(playerId);
+    isObserver = false;
+
+  } else {
+    const observer = state.observers.get(playerId);
+    self = {
+      id: observer.id,
+      name: observer.name,
+      color: observer.color,
+    };
+    isObserver = true;
+  }
+
+  const levelOverState = state.gameState === GameState.levelOver ? createLevelOver(state).data : null;
+
+  return messageInitial({
+    gameState: state.gameState,
+
+    self,
+
+    isObserver,
+
+    levelOverState,
+
+    leaderId: state.leaderId,
+
+    players: players.toArray(),
+
+    level: state.levelData,
+    expiresIn: state.expTime - Date.now(),
+
+    time: state.time,
+    matchEndsIn: state.matchEndTime - Date.now(),
+  });
+}
+
+export function createLevelOver(state: State) {
+  const rankedPlayers = state.roundRankedPlayers;
+
+  return messageLevelOver({
+    roundRankedPlayers: rankedPlayers.toArray().map((player) => {
+      return {
+        id: player.id,
+        color: player.color,
+        name: player.name,
+        strokes: player.strokes,
+        scoreTime: player.scoreTime,
+        scored: player.scored,
+
+        prevPoints: player.prevPoints,
+        addedPoints: player.points - player.prevPoints,
+      };
+    }),
+
+    expTime: state.expTime,
+    leaderId: state.leaderId,
+  });
+}

--- a/src/server/messages.ts
+++ b/src/server/messages.ts
@@ -1,4 +1,4 @@
-import {messageLevelOver, messageInitial} from '../universal/protocol';
+import {messageLevelOver, messageInitial, messageMatchOver} from '../universal/protocol';
 import {State} from './records';
 import {GameState} from '../universal/constants';
 
@@ -38,6 +38,7 @@ export function createInitial(state: State, playerId: number) {
   }
 
   const levelOverState = state.gameState === GameState.levelOver ? createLevelOver(state).data : null;
+  const matchOverState = state.gameState === GameState.matchOver ? createMatchOver(state).data : null;
 
   return messageInitial({
     gameState: state.gameState,
@@ -47,6 +48,7 @@ export function createInitial(state: State, playerId: number) {
     isObserver,
 
     levelOverState,
+    matchOverState,
 
     leaderId: state.leaderId,
 
@@ -80,5 +82,22 @@ export function createLevelOver(state: State) {
 
     expTime: state.expTime,
     leaderId: state.leaderId,
+  });
+}
+
+export function createMatchOver(state: State) {
+  const rankedPlayers = state.matchRankedPlayers;
+
+  return messageMatchOver({
+    nextMatchIn: state.expTime - Date.now(),
+
+    matchRankedPlayers: rankedPlayers.toArray().map((player) => {
+      return {
+        id: player.id,
+        color: player.color,
+        name: player.name,
+        points: player.points,
+      };
+    }),
   });
 }

--- a/src/server/records.ts
+++ b/src/server/records.ts
@@ -22,6 +22,7 @@ const PlayerRec = I.Record({
   scoreTime: null,
 
   points: 0,
+  prevPoints: 0,
 
   lastSwingTime: null,
 });
@@ -40,6 +41,7 @@ export class Player extends PlayerRec {
   scoreTime: number;
 
   points: number;
+  prevPoints: number;
 
   lastSwingTime: number;
 }

--- a/src/server/reducer.ts
+++ b/src/server/reducer.ts
@@ -74,21 +74,25 @@ export function updatePoints(players: I.Map<number, Player>, rankedPlayerIds: I.
   return rankedPlayerIds
     .reduce((players, rankedPlayerId, index) => {
       const scored = players.get(rankedPlayerId).scored;
-
       // don't award points to players who did not score
       if (!scored) {
         return players;
       }
 
+      const prevPoints = players.getIn([rankedPlayerId, 'points']);
+
       return players
+        .setIn([rankedPlayerId, 'points'], prevPoints)
         .updateIn([rankedPlayerId, 'points'],
-                  (points) => points + pointsForRank(index + 1, players.size));
+                  (points) => points + pointsForRank(index + 1, players.size))
     }, players);
 }
 
 function resetPoints(players: I.Map<number, Player>) {
   return players.map((player) => {
-    return player.set('points', 0);
+    return player
+      .set('points', 0)
+      .set('prevPoints', 0);
   });
 }
 

--- a/src/server/reducer.ts
+++ b/src/server/reducer.ts
@@ -84,7 +84,7 @@ export function updatePoints(players: I.Map<number, Player>, rankedPlayerIds: I.
       return players
         .setIn([rankedPlayerId, 'prevPoints'], prevPoints)
         .updateIn([rankedPlayerId, 'points'],
-                  (points) => points + pointsForRank(index + 1, players.size))
+                  (points) => points + pointsForRank(index + 1, players.size));
     }, players);
 }
 

--- a/src/server/reducer.ts
+++ b/src/server/reducer.ts
@@ -82,7 +82,7 @@ export function updatePoints(players: I.Map<number, Player>, rankedPlayerIds: I.
       const prevPoints = players.getIn([rankedPlayerId, 'points']);
 
       return players
-        .setIn([rankedPlayerId, 'points'], prevPoints)
+        .setIn([rankedPlayerId, 'prevPoints'], prevPoints)
         .updateIn([rankedPlayerId, 'points'],
                   (points) => points + pointsForRank(index + 1, players.size))
     }, players);

--- a/src/universal/protocol.ts
+++ b/src/universal/protocol.ts
@@ -47,11 +47,15 @@ export const TYPE_INITIAL = 'initial';
 // This message should always allow a complete reset of client state
 export interface MessageInitial {
   self: InitialPlayer;
-  gameState: GameState;
 
+  gameState: GameState;
   players: InitialPlayer[];
-  matchEndsIn: number;
   isObserver: boolean;
+
+  levelOverState?: MessageLevelOver;
+  matchOverState?: MessageMatchOver;
+
+  matchEndsIn: number;
 
   // TODO: this should all go under a "current round" sub-message or something. this message should
   // support sending information about "end of round" and "end of match" states too...

--- a/src/universal/protocol.ts
+++ b/src/universal/protocol.ts
@@ -9,17 +9,17 @@ interface Player {
   name: string;
 }
 
-interface Level {
-  points: Array<Array<number>>;
-  hole: Array<number>;
-  spawn: Array<number>;
-  color: string;
+interface InitialPlayer extends Player {
+  position: number[];
+  velocity: number[];
+  strokes: number;
+  scored: boolean;
 }
 
-interface Position {
+interface SyncPlayer {
   id: number;
-  x: number;
-  y: number;
+  position: number[];
+  velocity: number[];
 }
 
 interface LeaderboardPlayer extends Player {
@@ -34,13 +34,22 @@ interface MatchEndPlayer extends Player {
   points: number;
 }
 
+interface Level {
+  points: Array<Array<number>>;
+  hole: Array<number>;
+  spawn: Array<number>;
+  color: string;
+}
+
+
 export const TYPE_INITIAL = 'initial';
 
+// This message should always allow a complete reset of client state
 export interface MessageInitial {
-  self: Player;
+  self: InitialPlayer;
   gameState: GameState;
 
-  players: Array<Player>;
+  players: InitialPlayer[];
   matchEndsIn: number;
   isObserver: boolean;
 
@@ -135,12 +144,6 @@ export function messageLevel(params: MessageLevel) {
   };
 }
 
-
-interface SyncPlayer {
-  id: number;
-  position: number[];
-  velocity: number[];
-}
 
 export const TYPE_SYNC = 'sync';
 
@@ -265,5 +268,23 @@ export function messageMatchOver(params: MessageMatchOver) {
   return {
     type: TYPE_MATCH_OVER,
     data: params,
+  };
+}
+
+
+export const TYPE_REQUEST_PAUSE_STREAM = 'requestPauseStream';
+
+export function messageReqPauseStream() {
+  return {
+    type: TYPE_REQUEST_PAUSE_STREAM,
+  };
+}
+
+
+export const TYPE_REQUEST_RESUME_STREAM = 'requestResumeStream';
+
+export function messageReqResumeStream() {
+  return {
+    type: TYPE_REQUEST_RESUME_STREAM,
   };
 }

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -14,7 +14,7 @@ module.exports = webpackMerge(config, {
         NODE_ENV: '"production"',
         RAVEN_DSN: `"${secret.ravenDSNPublic}"`,
         BUILD_SHA: `"${sha}"`,
-        SERVER_URL: '"wss://manygolf.herokuapp.com/"'
+        SERVER_URL: `"${process.env.MANYGOLF_SERVER_URL}"` || `"wss://manygolf.herokuapp.com/"`
       }
     }),
 

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -14,7 +14,7 @@ module.exports = webpackMerge(config, {
         NODE_ENV: '"production"',
         RAVEN_DSN: `"${secret.ravenDSNPublic}"`,
         BUILD_SHA: `"${sha}"`,
-        SERVER_URL: `"${process.env.MANYGOLF_SERVER_URL}"` || `"wss://manygolf.herokuapp.com/"`
+        SERVER_URL: process.env.MANYGOLF_SERVER_URL ? `"${process.env.MANYGOLF_SERVER_URL}"` : `"wss://manygolf.herokuapp.com/"`
       }
     }),
 


### PR DESCRIPTION
Changes:
- Creates a p2 "world" for each ball, allowing each world to be easily rewound or fast-forwarded due to out of sync messaging
-  Removes predictive physics for player ball to prevent player ball out of sync errors until more robust checks are implemented

Todo:
- [ ] Fix issue where client time gets SUPER out of sync of server time and causes swings to never get played
  - This is a super tricky bug to reproduce
  - Sometimes clears itself up between holes?
  - Seems to be caused by massive lag on `MessageInitial`, which can happen if e.g. you tab out and tab back in while connecting to the server
- [ ] Fix bug where forward-skips on sync are still common
  - [ ] Record test case, since this is tricky to reproduce
- [ ] Fix "record skipping" issue where ball is continually reset to the same past position?
  - This could be an issue where the ball is asleep on the server but live on the browser, so it keeps rolling when it shouldn't
  - ...fuck :(
  -  To fix: sync awake/asleep state
- [x] Remove logging code (query string flagged)
- [x] Fix bug where tab out/in leads to incorrect time
  - [x] Think this is happening because the first tick after tabbing back in adds the full delta time from the time you were tabbed out
- [x] Fix issue where alt-tabbing out and back-in can cause a browser lock with lots of players (#23)
  - I think this is the game trying to replay way too many queued messages all at once, or trying to simulate physics over way too massive a delta-time
- [x] Prevent "replay" on tab back in on iPhone
  - Probably related to below alt-tab issue?
  - Test locally: Start bots on local game. Alt-tab out. Return. See game lock-up.
  - Something about replaying lots and lots of messages...
- [x] Fix bug when you alt-tab
- [x] Fix "you didn't make it in" text in leaderboard (`state.round.scored` not set?)
